### PR TITLE
SOLR-111 : Validate JSONP callback function name to avoid XSS

### DIFF
--- a/src/java/fr/paris/lutece/plugins/search/solr/util/SolrUtil.java
+++ b/src/java/fr/paris/lutece/plugins/search/solr/util/SolrUtil.java
@@ -70,6 +70,10 @@ public final class SolrUtil
     private static final String PROPERTY_ENCODE_URI_ENCODING = "search.encode.uri.encoding";
     private static final String DEFAULT_URI_ENCODING = "ISO-8859-1";
 
+    private static final String PROPERTY_CALLBACK_FUNCTION_NAME_PATTERN = "search.callbackFunctionName.pattern" ;
+    private static final String CONSTANT_DEFAULT_FUNCTION_NAME_PATTERN = "[_$A-Za-z0-9]+";
+    public  static final String PROPERTY_CALLBACK_FUNCTION_NAME_ERROR_MESSAGE = "search.callbackFunctionName.error.message" ;
+
     /**
      * Empty private constructor
      */
@@ -200,5 +204,18 @@ public final class SolrUtil
         String strURIEncoding = AppPropertiesService.getProperty( PROPERTY_ENCODE_URI_ENCODING, DEFAULT_URI_ENCODING );
 
         return strURIEncoding;
+    }
+
+    /**
+     * Test if the name is a valid javascript function name
+     *
+     * @param strName 
+     * @return  true if valid
+     */
+    public static boolean isValidJavascriptFunctionName( String strName )
+    {
+        String strFunctionNamePattern = AppPropertiesService.getProperty( PROPERTY_CALLBACK_FUNCTION_NAME_PATTERN, CONSTANT_DEFAULT_FUNCTION_NAME_PATTERN );
+
+        return  ( strName != null && strName.matches( strFunctionNamePattern ) ) ;
     }
 }

--- a/src/java/fr/paris/lutece/plugins/search/solr/web/SolrSuggestServlet.java
+++ b/src/java/fr/paris/lutece/plugins/search/solr/web/SolrSuggestServlet.java
@@ -34,6 +34,8 @@
 package fr.paris.lutece.plugins.search.solr.web;
 
 import fr.paris.lutece.plugins.search.solr.business.SolrSearchEngine;
+import fr.paris.lutece.plugins.search.solr.util.SolrUtil;
+import fr.paris.lutece.portal.service.util.AppPropertiesService;
 
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.client.solrj.response.SpellCheckResponse.Collation;
@@ -59,6 +61,7 @@ public class SolrSuggestServlet extends HttpServlet
 {
     private static final long serialVersionUID = -3273825949482572338L;
 
+     
     public void init(  )
     {
     }
@@ -76,6 +79,13 @@ public class SolrSuggestServlet extends HttpServlet
 
         SolrSearchEngine engine = SolrSearchEngine.getInstance(  );
         StringBuffer result = new StringBuffer(  );
+
+        // XSS control
+        if ( !SolrUtil.isValidJavascriptFunctionName( callback ) )
+        {
+            return AppPropertiesService.getProperty( SolrUtil.PROPERTY_CALLBACK_FUNCTION_NAME_ERROR_MESSAGE, "Invalid function name" ) ;
+        }
+
         result.append( callback );
 
         result.append( "({\"response\":{\"docs\":[" );

--- a/webapp/WEB-INF/conf/plugins/search-solr.properties
+++ b/webapp/WEB-INF/conf/plugins/search-solr.properties
@@ -67,3 +67,7 @@ solr.field.or=OR
 solr.field.switch=SWITCH
 
 solr.field.and=AND
+
+#Callback jsonp function control
+search.callbackFunctionName.pattern=[_$A-Za-z0-9]+
+search.callbackFunctionName.error.message=Invalid Function Name


### PR DESCRIPTION
callback function name in JSONP requests must match "[_\\-A-Za-z0-9]+"